### PR TITLE
fix: preview modal not displaying pictures

### DIFF
--- a/web/bilboxContextMenuEnhance.js
+++ b/web/bilboxContextMenuEnhance.js
@@ -109,29 +109,6 @@ app.registerExtension({
 			head.appendChild(link);
 		}
 
-		function setup_tooltips(combo_name)
-		{
-			var cname = combo_name.replace("_"," ");
-			if(!(cname in window.bilbox_promptgeek_data))
-				return;
-			var data = bilbox_promptgeek_data[cname].reduce(
-				(obj, item) => Object.assign(obj, { [item["name"]]: item }), {});
-			const items = Array.from(document.querySelectorAll(".litemenu-entry"));
-			for (var e of items) {
-				var title = e.innerText;
-				if(title in data)
-				{
-					//e.setAttribute('data-tooltip', data[title]["description"]);
-					var img = relPath+'/PromptGeek/'+ data[title]["images"][0]
-					e.innerHTML += '<span><img src="'+img+'">'+
-						'<a href="https://www.youtube.com/@promptgeek">PromptGeek\'s Youtube</a><br>'+
-						'<a href="https://promptgeek.gumroad.com/l/photoreal">PromptGeek\'s "Photoreal" Book</a><br>'+
-						'<h3>'+ title+'</h3><p align="justify">'+data[title]["description"]+'</p></span>';
-					e.classList.add("tooltip");
-				}
-			}
-		}
-
 		function setup_selection_modal(combo_name, callback)
 		{
 			var container = null;
@@ -270,8 +247,6 @@ app.registerExtension({
 								widget: w,
 							},
 							ref_window);
-
-						setup_tooltips(w.name);
 					}
 				}
 			}

--- a/web/bilboxContextMenuEnhance.js
+++ b/web/bilboxContextMenuEnhance.js
@@ -1,5 +1,4 @@
 import { app } from "../../scripts/app.js";
-import { api } from "../../scripts/api.js"
 
 // Inverts the scrolling of context menus
 const ActivateNodeType = "BilboXPhotoPrompt"
@@ -184,7 +183,7 @@ app.registerExtension({
 		}
 
 		installCss()
-		api.fetchApi('/extensions/bilbox-comfyui/PromptGeek/photo_data.json')
+		fetch('/extensions/bilbox-comfyui/PromptGeek/photo_data.json')
     		.then((response) => response.json())
     		.then((json) => window.bilbox_promptgeek_data = json);
 


### PR DESCRIPTION
This PR fixes the modal previews not loading. ComfyUI updated their front end which made the fetchApi function now prepend "/api/" to the requested link. The setup_tooltips function was removed as it was causing issues with the tooltip rendering when the modal previews were turned off.

Fixed by fetching the "photo_data.json" file directly.

Fixes: #23 #22 #20 

Before:
![CleanShot 2024-09-02 at 15 07 24@2x](https://github.com/user-attachments/assets/0bb8e991-9e8d-47fa-aebe-640b8b6cc568)

After:
![CleanShot 2024-09-02 at 15 05 02@2x](https://github.com/user-attachments/assets/f5b32fe3-e9bb-436b-810a-7a415a19da68)
